### PR TITLE
remove second concurrency group from deploy pipeline, only qa pipelin…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,6 @@ on:
     branches: 
       - main
 
-concurrency:
-  group: qa-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   quality-assurance:
     uses: ./.github/workflows/qa.yml


### PR DESCRIPTION
…e is cancelable, its just for testing because after merge QA pipeline failes with missing data. strange.